### PR TITLE
Fix error in formatting the expiration timestamp

### DIFF
--- a/main.js
+++ b/main.js
@@ -42,7 +42,7 @@ function s3instance(accessKey, secretKey) {
         var dateObj = new Date;
         var dateExp = new Date(dateObj.getTime() + duration * 1000);
         var policy = {
-            "expiration":dateExp.getUTCFullYear() + "-" + dateExp.getUTCMonth() + 1 + "-" + dateExp.getUTCDate() + "T" + dateExp.getUTCHours() + ":" + dateExp.getUTCMinutes() + ":" + dateExp.getUTCSeconds() + "Z",
+            "expiration":dateExp.getUTCFullYear() + "-" + (dateExp.getUTCMonth() + 1) + "-" + dateExp.getUTCDate() + "T" + dateExp.getUTCHours() + ":" + dateExp.getUTCMinutes() + ":" + dateExp.getUTCSeconds() + "Z",
             "conditions":[
                 { "bucket":bucket },
                 ["eq", "$key", key],


### PR DESCRIPTION
In calculating the expiration timestamp, the minutes value and the 1 is concatenated (as a string) instead of added arithmetically.
